### PR TITLE
docs: add contributor guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Contributor Guidelines
+
+- **Code style:** Follow [PEP 8](https://peps.python.org/pep-0008/) conventions.
+- **Formatting:** Run `black .` before committing to ensure consistent formatting.
+- **Linting:** Use `ruff check .` to validate the code.
+- **Testing:** Verify functionality with `pytest`.
+- **CI expectations:** Pull requests are expected to pass the same `ruff`, `black`, and `pytest` checks in continuous integration.
+- **Local checks:** Prior to committing, run `black .`, `ruff check .`, and `pytest` locally.
+- **Feature requirements:** Consult [spec.md](spec.md) for feature scope and requirements.
+


### PR DESCRIPTION
## Summary
- establish repository-wide contributor guidelines
- document code style, linting, testing, and CI expectations
- reference `spec.md` for feature requirements

## Testing
- `ruff check .` *(fails: unused imports, E701/E702 issues)*
- `black --check .` *(fails: would reformat codex-cli-linker.py)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5e6497abc8325a678d046c16f94b5