### PR TITLE
Add verbose logging flag and tests

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,11 @@ python3 codex-cli-linker.py \
 python3 codex-cli-linker.py --json --yaml
 ```
 
+**Show verbose logging for troubleshooting:**
+```bash
+python3 codex-cli-linker.py --verbose --auto
+```
+
 ---
 
 ## Installation
@@ -149,6 +154,9 @@ python3 codex-cli-linker.py [options]
 **Output formats**
 - `--json` — also write `~/.codex/config.json`
 - `--yaml` — also write `~/.codex/config.yaml`
+
+**Diagnostics**
+- `--verbose` — enable INFO/DEBUG logging
 
 > The `--launch` flag is intentionally disabled; the script prints the exact `codex --profile <name>` command instead of auto‑launching.
 

--- a/spec.md
+++ b/spec.md
@@ -70,6 +70,9 @@ save linker state → show next‑step hints
 
 > All flags are provided by `argparse` in `codex-cli-linker.py`.
 
+### General
+- `--verbose` — enable INFO/DEBUG logging output
+
 ### Base selection & model
 - `--auto` — auto‑detect base URL and skip base‑URL prompt
 - `--base-url <URL>` — override base URL (e.g., `http://localhost:1234/v1`)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,31 @@
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "codex_cli_linker", Path(__file__).resolve().parents[1] / "codex-cli-linker.py"
+)
+cli = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = cli
+spec.loader.exec_module(cli)
+
+
+def test_logging_default_level(monkeypatch, caplog):
+    monkeypatch.setattr(sys, "argv", ["codex-cli-linker.py"])
+    args = cli.parse_args()
+    cli.configure_logging(args.verbose)
+    logging.debug("debug")
+    logging.info("info")
+    logging.warning("warn")
+    assert [r.getMessage() for r in caplog.records] == ["warn"]
+
+
+def test_logging_verbose_level(monkeypatch, caplog):
+    monkeypatch.setattr(sys, "argv", ["codex-cli-linker.py", "--verbose"])
+    args = cli.parse_args()
+    cli.configure_logging(args.verbose)
+    logging.debug("debug")
+    logging.info("info")
+    logging.warning("warn")
+    assert [r.getMessage() for r in caplog.records] == ["debug", "info", "warn"]


### PR DESCRIPTION
## Summary
- add `--verbose` CLI option and configure logging
- document verbose flag in spec and README
- cover logging levels with new unit tests

## Testing
- `black codex-cli-linker.py tests/test_logging.py`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b61a33bf10832592a4607089d4b4ec