### PR TITLE
Add dry-run mode to preview configurations

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,7 @@ This small, dependency‑free Python script:
 - Emits a modern **`~/.codex/config.toml`** (Codex “# Config” schema) and can optionally emit **JSON** and **YAML** siblings.
 - Backs up any existing config (adds `.bak`).
 - Stores a tiny linker state (`~/.codex/linker_config.json`) to remember your last choices.
+- Preview the would-be files with `--dry-run` (prints to stdout, no writes).
 
 > Works on macOS, Linux, and Windows. No third‑party Python packages required.
 
@@ -97,7 +98,7 @@ Requirements:
    If detection fails, you can select a preset, enter a custom URL, or use your last saved URL.
 2. **Model pick** — Calls `GET <base>/models` and lists `data[*].id` for selection.
 3. **Config synthesis** — Builds a single in‑memory config object that mirrors the TOML schema (root keys + `[model_providers.<id>]` + `[profiles.<name>]`).
-4. **Emission & backup** — Writes `~/.codex/config.toml` (always) and, if requested, `config.json`/`config.yaml`. Any existing file is backed up to `*.bak` first.
+4. **Emission & backup** — Writes `~/.codex/config.toml` (always unless `--dry-run`) and, if requested, `config.json`/`config.yaml`. Any existing file is backed up to `*.bak` first.
 5. **State** — Saves `~/.codex/linker_config.json` so next run can preload your last base URL, provider, profile, and model.
 
 ---
@@ -106,7 +107,7 @@ Requirements:
 
 By default, files live under **`$CODEX_HOME`** (defaults to `~/.codex`).
 
-- `config.toml`  ← always written
+- `config.toml`  ← always written unless `--dry-run`
 - `config.json`  ← when `--json` is passed
 - `config.yaml`  ← when `--yaml` is passed
 - `linker_config.json` ← small helper file this tool uses to remember your last choices
@@ -154,6 +155,7 @@ python3 codex-cli-linker.py [options]
 **Output formats**
 - `--json` — also write `~/.codex/config.json`
 - `--yaml` — also write `~/.codex/config.yaml`
+- `--dry-run` — print configs to stdout without writing files
 
 **Diagnostics**
 - `--verbose` — enable INFO/DEBUG logging

--- a/spec.md
+++ b/spec.md
@@ -116,6 +116,7 @@ save linker state → show next‑step hints
 ### Output toggles
 - `--json` — also write `~/.codex/config.json`
 - `--yaml` — also write `~/.codex/config.yaml`
+- `--dry-run` — print configs to stdout without writing or backing up files
 
 > A `--launch` flag exists but is a no‑op by design (manual Codex launch is recommended). The script can inform how to run: `codex --profile <name>` or `npx codex --profile <name>`.
 
@@ -125,7 +126,7 @@ save linker state → show next‑step hints
 
 - **CODEX_HOME**: `~/.codex` unless overridden by env `CODEX_HOME`.
 - **Config outputs**
-  - `~/.codex/config.toml` (always written)
+  - `~/.codex/config.toml` (always written unless `--dry-run`)
   - `~/.codex/config.json` (optional)
   - `~/.codex/config.yaml` (optional)
 - **Backups**: When rewriting, existing files are moved to `<name>.<ext>.bak` (single backup slot).
@@ -374,14 +375,13 @@ python codex-cli-linker.py \
 
 - **Local server variations**: `/models` may vary across vendors; emitter and model parsing written defensively and tolerate absent fields.
 - **User confusion about API keys**: Provide explicit messaging that local servers usually ignore keys and that the script does **not** store secrets.
-- **Overwriting configs**: Single backup to prevent data loss; consider adding `--dry-run` (future) to preview.
+- **Overwriting configs**: Single backup to prevent data loss; `--dry-run` previews without touching files.
 - **Non‑localhost servers**: Currently allowed; advise caution and consider `https` controls for remote endpoints (future work).
 
 ---
 
 ## 15) Roadmap (Future Enhancements)
 
-- Add `--dry-run` to print would‑be TOML without writing.
 - Add `--allow-remote-http` gate and `--require-https` for non‑localhost URLs.
 - Optional multi‑provider emission (write multiple `[model_providers.*]` entries and multiple named profiles in one run).
 - Model filtering/search in interactive picker (by substring, family, parameter count if available).

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1,0 +1,47 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def load_cli(tmp_path):
+    spec = importlib.util.spec_from_file_location(
+        "codex_cli_linker", Path(__file__).resolve().parents[1] / "codex-cli-linker.py"
+    )
+    cli = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = cli
+    spec.loader.exec_module(cli)
+    return cli
+
+
+def test_dry_run_prints_and_writes_nothing(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    cli = load_cli(tmp_path)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "codex-cli-linker.py",
+            "--base-url",
+            "http://localhost:1234/v1",
+            "--model",
+            "foo",
+            "--auto",
+            "--json",
+            "--yaml",
+            "--dry-run",
+            "--model-context-window",
+            "1",
+        ],
+    )
+    # Avoid noisy screen clearing/banner
+    monkeypatch.setattr(cli, "clear_screen", lambda: None)
+    monkeypatch.setattr(cli, "banner", lambda: None)
+    cli.main()
+    out = capsys.readouterr().out
+    assert 'model = "foo"' in out
+    assert '"model": "foo"' in out
+    assert 'model_provider: "lmstudio"' in out or "model_provider: lmstudio" in out
+    assert not (tmp_path / "config.toml").exists()
+    assert not (tmp_path / "config.json").exists()
+    assert not (tmp_path / "config.yaml").exists()
+    assert not (tmp_path / "linker_config.json").exists()


### PR DESCRIPTION
## Summary
- support `--dry-run` CLI flag to print TOML/JSON/YAML instead of writing files
- document dry-run usage in spec and readme
- test dry-run to ensure no files are created

## Testing
- `python -m black .`
- `python -m ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b61ee7ab308325ac7c9c24eca6629f