### PR TITLE
feat: timestamped config backups

### DIFF
--- a/codex-cli-linker.py
+++ b/codex-cli-linker.py
@@ -41,6 +41,7 @@ import sys
 import re
 import urllib.error
 import urllib.request
+from datetime import datetime
 from dataclasses import dataclass, asdict
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
@@ -243,9 +244,10 @@ def try_auto_context_window(base_url: str, model_id: str) -> int:
 
 
 def backup(path: Path):
-    """Keep a single .bak so the user can roll back easily."""
+    """Backup existing file with a timestamped suffix."""
     if path.exists():
-        bak = path.with_suffix(path.suffix + ".bak")
+        stamp = datetime.now().strftime("%Y%m%d-%H%M")
+        bak = path.with_suffix(f"{path.suffix}.{stamp}.bak")
         try:
             path.replace(bak)
             info(f"Backed up existing {path.name} → {bak.name}")

--- a/spec.md
+++ b/spec.md
@@ -129,7 +129,7 @@ save linker state → show next‑step hints
   - `~/.codex/config.toml` (always written unless `--dry-run`)
   - `~/.codex/config.json` (optional)
   - `~/.codex/config.yaml` (optional)
-- **Backups**: When rewriting, existing files are moved to `<name>.<ext>.bak` (single backup slot).
+- **Backups**: When rewriting, existing files are moved to `<name>.<ext>.<YYYYMMDD-HHMM>.bak` allowing multiple versions to accumulate.
 - **Linker state**: `~/.codex/linker_config.json` (stores base URL, provider id, profile name, model id; **no secrets**).
 - **Helper scripts**: `scripts/set_env.sh` and `scripts/set_env.bat` — set `NULLKEY` env var.
 

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,0 +1,43 @@
+import datetime
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def load_cli():
+    spec = importlib.util.spec_from_file_location(
+        "codex_cli_linker", Path(__file__).resolve().parents[1] / "codex-cli-linker.py"
+    )
+    cli = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = cli
+    spec.loader.exec_module(cli)
+    return cli
+
+
+def test_backup_creates_unique_versions(monkeypatch, tmp_path):
+    cli = load_cli()
+    target = tmp_path / "config.toml"
+    target.write_text("one", encoding="utf-8")
+
+    class Time1:
+        @staticmethod
+        def now():
+            return datetime.datetime(2025, 1, 1, 12, 30)
+
+    class Time2:
+        @staticmethod
+        def now():
+            return datetime.datetime(2025, 1, 1, 12, 31)
+
+    monkeypatch.setattr(cli, "datetime", Time1)
+    cli.backup(target)
+
+    target.write_text("two", encoding="utf-8")
+    monkeypatch.setattr(cli, "datetime", Time2)
+    cli.backup(target)
+
+    backups = sorted(p.name for p in tmp_path.glob("config.toml.*.bak"))
+    assert backups == [
+        "config.toml.20250101-1230.bak",
+        "config.toml.20250101-1231.bak",
+    ]


### PR DESCRIPTION
## Summary
- append datetime hashes to backup filenames for versioned config history
- document multi-version backups in Files, Paths & Persistence
- test backup uniqueness across runs

## Testing
- `black .`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6243b596083259e8d823efe91608c