### PR TITLE
feat: preload config defaults from remote URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,7 @@ This small, dependency‑free Python script:
 - Emits a modern **`~/.codex/config.toml`** (Codex “# Config” schema) and can optionally emit **JSON** and **YAML** siblings.
 - Backs up any existing config (adds `.bak`).
 - Stores a tiny linker state (`~/.codex/linker_config.json`) to remember your last choices.
+- Can preload defaults from a remote JSON via `--config-url`.
 - Preview the would-be files with `--dry-run` (prints to stdout, no writes).
 
 > Works on macOS, Linux, and Windows. No third‑party Python packages required.
@@ -67,6 +68,11 @@ python3 codex-cli-linker.py --json --yaml
 **Show verbose logging for troubleshooting:**
 ```bash
 python3 codex-cli-linker.py --verbose --auto
+```
+
+**Preload defaults from a remote JSON:**
+```bash
+python3 codex-cli-linker.py --config-url https://example.com/defaults.json --auto
 ```
 
 ---

--- a/spec.md
+++ b/spec.md
@@ -22,6 +22,7 @@
 - Optionally emit `config.json` and `config.yaml` siblings
 - Back up existing config files before writing
 - Persist lightweight linker state (no secrets) to `~/.codex/linker_config.json`
+- Merge remote default values via `--config-url` before prompting
 - Offer helpful, colorized, cross‑platform UX
 
 ### Non‑Goals
@@ -72,6 +73,7 @@ save linker state → show next‑step hints
 
 ### General
 - `--verbose` — enable INFO/DEBUG logging output
+- `--config-url <URL>` — preload defaults from a JSON config before prompts
 
 ### Base selection & model
 - `--auto` — auto‑detect base URL and skip base‑URL prompt

--- a/tests/test_config_url.py
+++ b/tests/test_config_url.py
@@ -1,0 +1,87 @@
+import importlib.util
+import sys
+import urllib.error
+from pathlib import Path
+
+
+def load_cli():
+    spec = importlib.util.spec_from_file_location(
+        "codex_cli_linker", Path(__file__).resolve().parents[1] / "codex-cli-linker.py"
+    )
+    cli = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = cli
+    spec.loader.exec_module(cli)
+    return cli
+
+
+def test_config_url_applies_defaults(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    cli = load_cli()
+
+    class Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def read(self):
+            return b'{"approval_policy": "untrusted", "sandbox_mode": "read-only"}'
+
+    monkeypatch.setattr(cli.urllib.request, "urlopen", lambda url, timeout=3.0: Resp())
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "codex-cli-linker.py",
+            "--base-url",
+            "http://localhost:1234/v1",
+            "--model",
+            "foo",
+            "--auto",
+            "--config-url",
+            "http://example.com/defs.json",
+            "--model-context-window",
+            "1",
+            "--dry-run",
+        ],
+    )
+    monkeypatch.setattr(cli, "clear_screen", lambda: None)
+    monkeypatch.setattr(cli, "banner", lambda: None)
+    cli.main()
+    out = capsys.readouterr().out
+    assert 'approval_policy = "untrusted"' in out
+    assert 'sandbox_mode = "read-only"' in out
+
+
+def test_config_url_fetch_error(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    cli = load_cli()
+
+    def boom(url, timeout=3.0):
+        raise urllib.error.URLError("bad url")
+
+    monkeypatch.setattr(cli.urllib.request, "urlopen", boom)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "codex-cli-linker.py",
+            "--base-url",
+            "http://localhost:1234/v1",
+            "--model",
+            "foo",
+            "--auto",
+            "--config-url",
+            "http://example.com/defs.json",
+            "--model-context-window",
+            "1",
+            "--dry-run",
+        ],
+    )
+    monkeypatch.setattr(cli, "clear_screen", lambda: None)
+    monkeypatch.setattr(cli, "banner", lambda: None)
+    cli.main()
+    out = capsys.readouterr().out
+    assert 'approval_policy = "on-failure"' in out
+    assert "Failed to fetch config defaults" in out


### PR DESCRIPTION
## Summary
- add `--config-url` arg to preload defaults from a JSON endpoint
- merge downloaded defaults before prompts
- document remote config option in spec and README
- cover remote config handling in tests

## Testing
- `black .`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6db62e23083258f2b0a9e6dbb8702