### PR TITLE
Add full-auto mode with parallel detection

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,9 +46,10 @@ python3 codex-cli-linker.py
 codex --profile lmstudio      # or: npx codex --profile lmstudio
 ```
 
-**Non‑interactive / auto‑detect:**
+**Non‑interactive:**
 ```bash
-python3 codex-cli-linker.py --auto
+python3 codex-cli-linker.py --auto        # detect server, still prompts for model
+python3 codex-cli-linker.py --full-auto   # detect server and first model (no prompts)
 ```
 
 **Target a specific server/model:**
@@ -130,6 +131,8 @@ python3 codex-cli-linker.py [options]
 
 **Connection & selection**
 - `--auto` — skip base‑URL prompt and auto‑detect a server
+- `--full-auto` — imply `--auto` and pick the first model with no prompts
+- `--model-index <N>` — with `--auto`/`--full-auto`, pick model by list index (default 0)
 - `--base-url <URL>` — explicit OpenAI‑compatible base URL (e.g., `http://localhost:1234/v1`)
 - `--model <ID>` — model id to use (skips interactive model picker)
 - `--provider <ID>` — provider key for `[model_providers.<id>]` (e.g., `lmstudio`, `ollama`, `custom`)

--- a/spec.md
+++ b/spec.md
@@ -39,10 +39,11 @@
 - **New user:** Wants interactive prompts to choose base URL, model, and sane defaults.
 
 **Stories**
-1. As a user, I can run `python codex-cli-linker.py --auto` to detect LM Studio/Ollama and generate `~/.codex/config.toml`.
-2. As a user, I can run with `--base-url http://host:port/v1 --model <id>` to skip prompts and produce config directly.
-3. As a user, I can opt into JSON/YAML mirrors via `--json` and/or `--yaml`.
-4. As a user, my previous choices are remembered across runs.
+1. As a user, I can run `python codex-cli-linker.py --full-auto` to configure using the first available model with no prompts.
+2. As a user, I can run `python codex-cli-linker.py --auto` to detect LM Studio/Ollama and generate `~/.codex/config.toml`.
+3. As a user, I can run with `--base-url http://host:port/v1 --model <id>` to skip prompts and produce config directly.
+4. As a user, I can opt into JSON/YAML mirrors via `--json` and/or `--yaml`.
+5. As a user, my previous choices are remembered across runs.
 
 ---
 
@@ -56,7 +57,7 @@ save linker state → show next‑step hints
 ```
 
 **Server detection**
-- Probes in order: `http://localhost:1234/v1` (LM Studio), `http://localhost:11434/v1` (Ollama)
+- Probes `http://localhost:1234/v1` (LM Studio) and `http://localhost:11434/v1` (Ollama) concurrently; first responder wins.
 - Success when `/models` returns JSON with a `data` list.
 
 **Model listing**
@@ -77,8 +78,10 @@ save linker state → show next‑step hints
 
 ### Base selection & model
 - `--auto` — auto‑detect base URL and skip base‑URL prompt
+- `--full-auto` — imply `--auto` and pick the first available model with no prompts
 - `--base-url <URL>` — override base URL (e.g., `http://localhost:1234/v1`)
 - `--model <id>` — skip model picker (use the given id)
+- `--model-index <int>` — when auto-selecting, choose model by list index (default 0)
 - `--provider <id>` — provider id for `[model_providers.<id>]` (default inferred: `lmstudio`/`ollama`/`custom`)
 - `--profile <name>` — profile name (default deduced from provider)
 - `--api-key <val>` — dummy key to place in env var (local servers typically ignore)

--- a/tests/test_detect_parallel.py
+++ b/tests/test_detect_parallel.py
@@ -1,0 +1,31 @@
+import importlib.util
+import sys
+import time
+from pathlib import Path
+
+
+def load_cli():
+    spec = importlib.util.spec_from_file_location(
+        "codex_cli_linker", Path(__file__).resolve().parents[1] / "codex-cli-linker.py"
+    )
+    cli = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = cli
+    spec.loader.exec_module(cli)
+    return cli
+
+
+def test_detect_base_url_parallel(monkeypatch):
+    cli = load_cli()
+
+    def fake_http_get_json(url, timeout=3.0):
+        if "1234" in url:
+            time.sleep(0.5)
+            return None, "slow"
+        return {"data": []}, None
+
+    monkeypatch.setattr(cli, "http_get_json", fake_http_get_json)
+    start = time.perf_counter()
+    base = cli.detect_base_url([cli.DEFAULT_LMSTUDIO, cli.DEFAULT_OLLAMA])
+    elapsed = time.perf_counter() - start
+    assert base == cli.DEFAULT_OLLAMA
+    assert elapsed < 0.3

--- a/tests/test_full_auto.py
+++ b/tests/test_full_auto.py
@@ -1,0 +1,63 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def load_cli():
+    spec = importlib.util.spec_from_file_location(
+        "codex_cli_linker", Path(__file__).resolve().parents[1] / "codex-cli-linker.py"
+    )
+    cli = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = cli
+    spec.loader.exec_module(cli)
+    return cli
+
+
+def fake_models_response(url, timeout=3.0):
+    return {"data": [{"id": "m1"}, {"id": "m2"}]}, None
+
+
+def test_full_auto_selects_first_model(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    cli = load_cli()
+    monkeypatch.setattr(cli, "http_get_json", fake_models_response)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "codex-cli-linker.py",
+            "--full-auto",
+            "--dry-run",
+            "--model-context-window",
+            "1",
+        ],
+    )
+    monkeypatch.setattr(cli, "clear_screen", lambda: None)
+    monkeypatch.setattr(cli, "banner", lambda: None)
+    cli.main()
+    out = capsys.readouterr().out
+    assert 'model = "m1"' in out
+
+
+def test_model_index_override(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+    cli = load_cli()
+    monkeypatch.setattr(cli, "http_get_json", fake_models_response)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "codex-cli-linker.py",
+            "--full-auto",
+            "--model-index",
+            "1",
+            "--dry-run",
+            "--model-context-window",
+            "1",
+        ],
+    )
+    monkeypatch.setattr(cli, "clear_screen", lambda: None)
+    monkeypatch.setattr(cli, "banner", lambda: None)
+    cli.main()
+    out = capsys.readouterr().out
+    assert 'model = "m2"' in out


### PR DESCRIPTION
## Summary
- add `--full-auto` flag and optional `--model-index`
- probe candidate base URLs concurrently
- support non-interactive model auto-selection

## Testing
- `black .`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b71e17ec208325b9be41d59a1eada5