### PR TITLE
fix: add permissions and correct publish artifact path

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -45,6 +48,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: [lint, format, test]
+    permissions:
+      contents: read
+      actions: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -63,11 +69,13 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: [lint, format, test, build]
+    permissions:
+      contents: read
+      actions: read
     steps:
       - uses: actions/download-artifact@v4
         with:
           name: dist
-          path: dist
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
## Summary
- restrict GITHUB_TOKEN permissions for publish workflow
- fix artifact download path so PyPI publish step locates distributions

## Testing
- `black .`
- `ruff check .`
- `pytest`
- `python -m build` *(warning: sdist: standard file not found: should have one of README, README.rst, README.txt, README.md)*

------
https://chatgpt.com/codex/tasks/task_e_68b734e898c08325a666a81486c057b9