### PR TITLE
fix(ci): build dists, run checks, and enable OIDC for PyPI trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,85 +1,55 @@
-name: Publish
+name: Publish to PyPI
 
 on:
-  release:
-    types: [published]
+  push:
+    tags: ["v*"]
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
-  lint:
+  release:
     runs-on: ubuntu-latest
+
+    # REQUIRED for Trusted Publishing (OIDC)
+    permissions:
+      id-token: write
+      contents: read
+
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
-      - name: Install ruff
-        run: python -m pip install ruff
-      - name: Run ruff
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip build ruff black pytest
+
+      - name: Lint
         run: ruff check .
 
-  format:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-      - name: Install black
-        run: python -m pip install black
-      - name: Run black
+      - name: Check formatting
         run: black --check .
 
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-      - name: Install pytest
-        run: python -m pip install pytest
       - name: Run tests
         run: pytest
 
-  build:
-    runs-on: ubuntu-latest
-    needs: [lint, format, test]
-    permissions:
-      contents: read
-      actions: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-      - name: Install build tools
-        run: python -m pip install build
-      - name: Build distribution
-        run: python -m build
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: dist
+      - name: Build distributions
+        run: |
+          python -m build
+        # If your project is in a subdir, add:
+        # working-directory: ./path/to/pkg
 
-  publish:
-    runs-on: ubuntu-latest
-    needs: [lint, format, test, build]
-    permissions:
-      contents: read
-      actions: read
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: dist
-      - name: Publish to PyPI
+      - name: Verify artifacts exist
+        run: |
+          test -d dist && [ -n "$(ls -A dist)" ] || { echo "dist/ is empty"; ls -la; exit 1; }
+
+      - name: Publish to PyPI (Trusted Publisher via OIDC)
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          packages-dir: dist
-
+          skip-existing: true
+        # Do NOT set username/password when using OIDC
+        # If using TestPyPI, add:
+        # repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
## Summary
- build distributions before publishing and verify artifacts
- run lint, format, and tests before releasing to PyPI
- publish to PyPI via OIDC using pypa/gh-action-pypi-publish
- trigger workflow on tags (v*) and manual runs

## Testing
- `black .`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b75433a36c83258558f120929d55ec