### PR TITLE
feat: add cross-platform Codex launcher

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ cd codex-cli-linker
 python3 codex-cli-linker.py
 
 # 3) Launch Codex with the generated profile (shown at the end of the run)
-codex --profile lmstudio      # or: npx codex --profile lmstudio
+npx codex --profile lmstudio      # or: codex --profile lmstudio
 ```
 
 **Non‑interactive:**
@@ -163,7 +163,7 @@ python3 codex-cli-linker.py [options]
 **Diagnostics**
 - `--verbose` — enable INFO/DEBUG logging
 
-> The `--launch` flag is intentionally disabled; the script prints the exact `codex --profile <name>` command instead of auto‑launching.
+> The `--launch` flag is intentionally disabled; the script prints the exact `npx codex --profile <name>` command (or `codex --profile <name>` if installed) instead of auto‑launching.
 
 
 ## Config keys written
@@ -318,7 +318,9 @@ Key modules & functions:
 - **Detection** — `detect_base_url()`, `list_models()`
 - **Pickers** — `pick_base_url()`, `pick_model_interactive()`
 - **Config build** — `build_config_dict()` (single source of truth), emitters: `to_toml()`, `to_json()`, `to_yaml()`
-- **Codex CLI integration** — `find_codex_cmd()`, `ensure_codex_cli()`
+- **Codex CLI integration** — `find_codex_cmd()`, `ensure_codex_cli()`, `launch_codex()` for cross-platform (cmd, PowerShell, POSIX) launching with exit-code logging
+
+`launch_codex()` chooses the appropriate shell for the host OS and reports the Codex CLI's success or failure via exit codes.
 
 Run locally:
 ```bash

--- a/spec.md
+++ b/spec.md
@@ -123,7 +123,7 @@ save linker state → show next‑step hints
 - `--yaml` — also write `~/.codex/config.yaml`
 - `--dry-run` — print configs to stdout without writing or backing up files
 
-> A `--launch` flag exists but is a no‑op by design (manual Codex launch is recommended). The script can inform how to run: `codex --profile <name>` or `npx codex --profile <name>`.
+> A `--launch` flag exists but is a no‑op by design (manual Codex launch is recommended). The script can inform how to run: `npx codex --profile <name>` or `codex --profile <name>`. A helper `launch_codex(profile)` is available for cross‑platform execution (cmd, PowerShell, POSIX shells) and returns the CLI's exit code while logging the command.
 
 ---
 
@@ -260,7 +260,7 @@ approval_policy = "on-failure"
 - Colorized output with symbols (`✓`, `ℹ`, `!`, `✗`) when terminal supports color.
 - Numbered pick‑lists for base URL choice and model selection.
 - Graceful clamping of out‑of‑spec choices (e.g., `--reasoning-effort medium` → `low`).
-- Friendly post‑run summary with explicit `codex --profile …` hints.
+- Friendly post‑run summary with explicit `npx codex --profile …` (or `codex --profile …`) hints.
 
 ---
 
@@ -310,7 +310,7 @@ approval_policy = "on-failure"
   - **State:** `LinkerState` dataclass with `save`/`load` to `~/.codex/linker_config.json`
   - **Config:** `build_config_dict(state, args)` → dict; `to_toml`, `to_json`, `to_yaml` emitters
   - **I/O:** `backup(path)`; writing to `CONFIG_TOML|JSON|YAML`
-  - **Codex CLI detection:** `find_codex_cmd()`, `ensure_codex_cli()`, `launch_codex(profile)` (launch is user‑driven)
+  - **Codex CLI detection:** `find_codex_cmd()`, `ensure_codex_cli()`, `launch_codex(profile)` for cross‑platform launching (cmd, PowerShell, POSIX shells) with exit codes and logs
   - **Interaction:** `prompt_choice`, `prompt_yes_no`, `pick_base_url`, `pick_model_interactive`
   - **Entrypoint:** `main()` with `argparse` → flow orchestration
 
@@ -364,7 +364,7 @@ python codex-cli-linker.py \
 - Windows (PowerShell + `cmd`) & `.bat` helper; macOS/Linux with `.sh` helper; UTF‑8 output and color support checks.
 
 ### Manual Acceptance
-- With LM Studio running at `:1234`, run `--auto` and pick a model; inspect generated TOML; run `codex --profile <name>`.
+- With LM Studio running at `:1234`, run `--auto` and pick a model; inspect generated TOML; run `npx codex --profile <name>` (or `codex --profile <name>`).
 - With Ollama at `:11434`, repeat with an Ollama model id.
 
 ---

--- a/tests/test_launch_codex.py
+++ b/tests/test_launch_codex.py
@@ -1,0 +1,79 @@
+import importlib.util
+from pathlib import Path
+
+
+def load_cli():
+    spec = importlib.util.spec_from_file_location(
+        "codex_cli_linker", Path(__file__).resolve().parents[1] / "codex-cli-linker.py"
+    )
+    cli = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(cli)
+    return cli
+
+
+def make_run(monkeypatch, cli, expected_cmd, returncode):
+    def fake_run(cmd, **kwargs):
+        assert cmd == expected_cmd
+
+        class R:
+            pass
+
+        r = R()
+        r.returncode = returncode
+        return r
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+
+def test_launch_codex_posix(monkeypatch):
+    cli = load_cli()
+    monkeypatch.setattr(cli, "ensure_codex_cli", lambda: ["codex"])
+    monkeypatch.setattr(cli.os, "name", "posix")
+    make_run(monkeypatch, cli, ["codex", "--profile", "p"], 0)
+    assert cli.launch_codex("p") == 0
+
+
+def test_launch_codex_npx_posix(monkeypatch):
+    cli = load_cli()
+    monkeypatch.setattr(cli, "ensure_codex_cli", lambda: ["npx", "codex"])
+    monkeypatch.setattr(cli.os, "name", "posix")
+    make_run(monkeypatch, cli, ["npx", "codex", "--profile", "p"], 0)
+    assert cli.launch_codex("p") == 0
+
+
+def test_launch_codex_windows_cmd(monkeypatch):
+    cli = load_cli()
+    monkeypatch.setattr(cli, "ensure_codex_cli", lambda: ["codex"])
+    monkeypatch.setattr(cli.os, "name", "nt")
+    monkeypatch.setattr(cli.shutil, "which", lambda _: None)
+    make_run(monkeypatch, cli, ["cmd", "/c", "codex --profile p"], 5)
+    assert cli.launch_codex("p") == 5
+
+
+def test_launch_codex_windows_powershell(monkeypatch):
+    cli = load_cli()
+    monkeypatch.setattr(cli, "ensure_codex_cli", lambda: ["codex"])
+    monkeypatch.setattr(cli.os, "name", "nt")
+
+    def fake_which(name):
+        return "pwsh" if name == "powershell" else None
+
+    monkeypatch.setattr(cli.shutil, "which", fake_which)
+    make_run(
+        monkeypatch,
+        cli,
+        ["powershell", "-NoLogo", "-NoProfile", "-Command", "codex --profile p"],
+        0,
+    )
+    assert cli.launch_codex("p") == 0
+
+
+def test_find_codex_cmd_falls_back_to_npx(monkeypatch):
+    cli = load_cli()
+    monkeypatch.setattr(cli.os, "name", "posix")
+
+    def fake_which(name):
+        return None if name == "codex" else "/usr/bin/npx"
+
+    monkeypatch.setattr(cli.shutil, "which", fake_which)
+    assert cli.find_codex_cmd() == ["npx", "codex"]


### PR DESCRIPTION
## Summary
- handle Codex CLI launch on Windows (cmd and PowerShell) and POSIX shells
- return and log explicit exit codes
- document cross-platform launch behavior and add tests covering each platform
- prefer `npx codex` in docs and CLI hints

## Testing
- `black .`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b75be5e8c88325a779c132cb64bedc