### PR TITLE
Persist additional CLI state

### DIFF
--- a/codex-cli-linker.py
+++ b/codex-cli-linker.py
@@ -802,10 +802,23 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     p.add_argument(
         "--disable-response-storage",
         action="store_true",
+        dest="disable_response_storage",
         help="Set disable_response_storage=true (e.g., ZDR orgs)",
     )
     p.add_argument(
-        "--no-history", action="store_true", help="Set history.persistence=none"
+        "--enable-response-storage",
+        action="store_false",
+        dest="disable_response_storage",
+        help=argparse.SUPPRESS,
+    )
+    p.add_argument(
+        "--no-history",
+        action="store_true",
+        dest="no_history",
+        help="Set history.persistence=none",
+    )
+    p.add_argument(
+        "--history", action="store_false", dest="no_history", help=argparse.SUPPRESS
     )
     p.add_argument(
         "--azure-api-version", help="If targeting Azure, set query_params.api-version"
@@ -848,7 +861,18 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         help="Print config(s) to stdout without writing files",
     )
 
-    return p.parse_args(argv)
+    if argv is None:
+        argv = sys.argv[1:]
+    ns = p.parse_args(argv)
+    ns._explicit = {
+        a.dest
+        for a in p._actions
+        if any(
+            opt in argv or any(arg.startswith(opt + "=") for arg in argv)
+            for opt in a.option_strings
+        )
+    }
+    return ns
 
 
 def configure_logging(verbose: bool) -> None:
@@ -871,6 +895,26 @@ def merge_config_defaults(
     for k, v in data.items():
         if hasattr(args, k) and getattr(args, k) == getattr(defaults, k):
             setattr(args, k, v)
+            if hasattr(args, "_explicit"):
+                args._explicit.add(k)
+
+
+def apply_saved_state(
+    args: argparse.Namespace, defaults: argparse.Namespace, state: LinkerState
+) -> None:
+    specified = getattr(args, "_explicit", set())
+    for fld in (
+        "approval_policy",
+        "sandbox_mode",
+        "reasoning_effort",
+        "reasoning_summary",
+        "verbosity",
+        "disable_response_storage",
+        "no_history",
+        "history_max_bytes",
+    ):
+        if fld not in specified and getattr(args, fld) == getattr(defaults, fld):
+            setattr(args, fld, getattr(state, fld))
 
 
 # =============== Main flow ===============
@@ -890,18 +934,7 @@ def main():
     # Hard-disable auto launch regardless of flags
     args.launch = False
     state = LinkerState.load()
-    for fld in (
-        "approval_policy",
-        "sandbox_mode",
-        "reasoning_effort",
-        "reasoning_summary",
-        "verbosity",
-        "disable_response_storage",
-        "no_history",
-        "history_max_bytes",
-    ):
-        if getattr(args, fld) == getattr(defaults, fld):
-            setattr(args, fld, getattr(state, fld))
+    apply_saved_state(args, defaults, state)
 
     # Base URL: auto-detect or prompt
     base = args.base_url or pick_base_url(state, args.auto)


### PR DESCRIPTION
## Summary
- Track which CLI arguments were explicitly provided and only apply saved state when options are omitted
- Add `--enable-response-storage` and `--history` flags so booleans can be reset to defaults
- Test that explicit defaults override persisted values

## Testing
- `python -m black codex-cli-linker.py tests/test_state.py`
- `python -m ruff check tests/test_state.py codex-cli-linker.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b76bfc9d248325a86d9dc204a346fd