### PR TITLE
Add env key name flag

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -131,6 +131,8 @@ python3 codex-cli-linker.py [options]
 - `--model <ID>` — model id to use (skips interactive model picker)
 - `--provider <ID>` — provider key for `[model_providers.<id>]` (e.g., `lmstudio`, `ollama`, `custom`)
 - `--profile <NAME>` — profile name for `[profiles.<name>]` (default deduced from provider)
+- `--api-key <VAL>` — dummy key to place in an env var
+- `--env-key-name <NAME>` — env var name that holds the API key (default `NULLKEY`)
 
 **Behavior & UX**
 - `--approval-policy {untrusted,on-failure}` (default: `on-failure`)
@@ -188,6 +190,7 @@ At a glance, the script writes:
   - `name` — human label (e.g., "LM Studio", "Ollama")
   - `base_url` — your selected base URL, normalized
   - `wire_api = "chat"` — wire protocol used by Codex
+  - `api_key_env_var` — environment variable holding the API key
   - `request_max_retries`, `stream_max_retries`, `stream_idle_timeout_ms`
   - `query_params.api-version` *(when `--azure-api-version` is provided)*
 
@@ -271,7 +274,7 @@ ls ~/.codex/
 ## Environment variables
 
 - `CODEX_HOME` — overrides the config directory (default: `~/.codex`).
-- `NULLKEY` — a placeholder env var this tool initializes to `"nullkey"` so configs never need to include secrets.
+- `NULLKEY` — default env var this tool initializes to `"nullkey"` so configs never need to include secrets; change with `--env-key-name`.
   - Optional helper scripts:
     - macOS/Linux: `source scripts/set_env.sh`
     - Windows: `scripts\set_env.bat`

--- a/spec.md
+++ b/spec.md
@@ -85,6 +85,7 @@ save linker state → show next‑step hints
 - `--provider <id>` — provider id for `[model_providers.<id>]` (default inferred: `lmstudio`/`ollama`/`custom`)
 - `--profile <name>` — profile name (default deduced from provider)
 - `--api-key <val>` — dummy key to place in env var (local servers typically ignore)
+- `--env-key-name <name>` — env var to read API key from (default `NULLKEY`)
 
 ### Core config knobs (Codex config spec)
 - `--approval-policy` — default `on-failure` (allowed: `untrusted`, `on-failure`)
@@ -136,7 +137,7 @@ save linker state → show next‑step hints
   - `~/.codex/config.yaml` (optional)
 - **Backups**: When rewriting, existing files are moved to `<name>.<ext>.<YYYYMMDD-HHMM>.bak` allowing multiple versions to accumulate.
 - **Linker state**: `~/.codex/linker_config.json` (stores base URL, provider id, profile name, model id, approval policy, sandbox mode, reasoning defaults, verbosity, and history toggles; **no secrets**).
-- **Helper scripts**: `scripts/set_env.sh` and `scripts/set_env.bat` — set `NULLKEY` env var.
+- **Helper scripts**: `scripts/set_env.sh` and `scripts/set_env.bat` — set `NULLKEY` env var (customizable via `--env-key-name`).
 
 ---
 
@@ -177,6 +178,7 @@ save linker state → show next‑step hints
 name = "LM Studio" | "Ollama" | <Capitalized custom>
 base_url = "http://localhost:1234/v1"  # or custom
 wire_api = "chat"
+api_key_env_var = "NULLKEY"
 request_max_retries = 4
 stream_max_retries = 10
 stream_idle_timeout_ms = 300000
@@ -268,7 +270,8 @@ approval_policy = "on-failure"
 
 - **No secrets persisted:**
   - Linker state (`linker_config.json`) stores only non‑sensitive selections.
-  - Default env var name for API key is `NULLKEY`; helper scripts set it to `"nullkey"`.
+  - Default env var name for API key is `NULLKEY`; override with `--env-key-name`.
+    Helper scripts set the variable to `"nullkey"` by default.
   - Do **not** prompt for or store real API keys; local servers typically ignore keys.
 - **Backups:** Single `.bak` rotation on config files to avoid accidental loss.
 - **Network:**

--- a/tests/test_env_key.py
+++ b/tests/test_env_key.py
@@ -1,0 +1,24 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def load_cli():
+    spec = importlib.util.spec_from_file_location(
+        "codex_cli_linker", Path(__file__).resolve().parents[1] / "codex-cli-linker.py"
+    )
+    cli = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = cli
+    spec.loader.exec_module(cli)
+    return cli
+
+
+def test_env_key_name_in_config():
+    cli = load_cli()
+    args = cli.parse_args(["--env-key-name", "MYKEY"])
+    state = cli.LinkerState()
+    if "env_key_name" in getattr(args, "_explicit", set()):
+        state.env_key = args.env_key_name
+    cfg = cli.build_config_dict(state, args)
+    assert state.env_key == "MYKEY"
+    assert cfg["model_providers"][state.provider]["api_key_env_var"] == "MYKEY"


### PR DESCRIPTION
## Summary
- allow setting a custom API key environment variable with `--env-key-name`
- persist and emit the chosen env key under `api_key_env_var`
- document env key option and add test coverage

## Testing
- `black .`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8299cb6f48325877dc0f19cee8f23