### PR TITLE
fix: ensure publish workflow builds and uploads dist

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,11 @@ on:
     tags: ["v*"]
   workflow_dispatch:
 
+# Ensure the job can request an OIDC token and read the repository
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -38,7 +43,7 @@ jobs:
 
       - name: Build distributions
         run: |
-          python -m build
+          python -m build --outdir dist
         # If your project is in a subdir, add:
         # working-directory: ./path/to/pkg
 
@@ -50,6 +55,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true
+          packages-dir: dist
         # Do NOT set username/password when using OIDC
         # If using TestPyPI, add:
         # repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
## Summary
- ensure publish workflow can request OIDC tokens by setting permissions
- explicitly build package to `dist` and upload from there

## Testing
- `black .`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b82ad52c1c8325bbc73a7a37c40cf4