### PR TITLE
feat: add logging handlers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,21 @@ python3 codex-cli-linker.py --json --yaml
 python3 codex-cli-linker.py --verbose --auto
 ```
 
+**Log to a file:**
+```bash
+python3 codex-cli-linker.py --log-file linker.log
+```
+
+**Emit logs as JSON:**
+```bash
+python3 codex-cli-linker.py --log-json
+```
+
+**Send logs to a remote HTTP endpoint:**
+```bash
+python3 codex-cli-linker.py --log-remote http://example.com/log
+```
+
 **Preload defaults from a remote JSON:**
 ```bash
 python3 codex-cli-linker.py --config-url https://example.com/defaults.json --auto
@@ -164,6 +179,9 @@ python3 codex-cli-linker.py [options]
 
 **Diagnostics**
 - `--verbose` — enable INFO/DEBUG logging
+- `--log-file <PATH>` — append logs to a file
+- `--log-json` — also emit logs as JSON to stdout
+- `--log-remote <URL>` — POST log records to an HTTP endpoint
 
 > The `--launch` flag is intentionally disabled; the script prints the exact `npx codex --profile <name>` command (or `codex --profile <name>` if installed) instead of auto‑launching.
 

--- a/spec.md
+++ b/spec.md
@@ -76,6 +76,11 @@ save linker state → show next‑step hints
 - `--verbose` — enable INFO/DEBUG logging output
 - `--config-url <URL>` — preload defaults from a JSON config before prompts
 
+### Logging
+- `--log-file <PATH>` — append logs to a file
+- `--log-json` — also emit logs as JSON to stdout
+- `--log-remote <URL>` — POST log records to an HTTP endpoint
+
 ### Base selection & model
 - `--auto` — auto‑detect base URL and skip base‑URL prompt
 - `--full-auto` — imply `--auto` and pick the first available model with no prompts


### PR DESCRIPTION
## Summary
- add file, JSON, and remote logging options with new CLI flags
- document logging handlers in spec and README
- test file and HTTP log handlers

## Testing
- `black codex-cli-linker.py tests/test_logging.py`
- `ruff check codex-cli-linker.py tests/test_logging.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8807b79f08325978e2757a5c0c34b