### PR TITLE
Add pytest-cov to development dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,14 @@ license = "MIT"
 authors = [{name = "Mariana"}]
 requires-python = ">=3.8"
 
+[project.optional-dependencies]
+dev = [
+  "pytest",
+  "pytest-cov",
+  "ruff",
+  "black",
+]
+
 [tool.setuptools]
 script-files = ["codex-cli-linker.py"]
 


### PR DESCRIPTION
## Summary
- declare pytest-cov as a development dependency so default coverage flags work

## Testing
- `black .`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b88257bb608325bffad6fd7fadb4ce