### PR TITLE
fix: import logging handlers for remote logging

### DIFF
--- a/codex-cli-linker.py
+++ b/codex-cli-linker.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import logging.handlers
 import os
 import shutil
 import subprocess

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,6 +1,5 @@
 import importlib.util
 import logging
-import logging.handlers
 import sys
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- import `logging.handlers` so `--log-remote` works without extra imports
- drop redundant `logging.handlers` import in tests to cover regression

## Testing
- `black .`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8862df028832587a34298b2888cd7