### PR TITLE
fix: escape JSON log messages

### DIFF
--- a/codex-cli-linker.py
+++ b/codex-cli-linker.py
@@ -905,10 +905,15 @@ def configure_logging(
     logger.addHandler(stream)
 
     if log_json:
+
+        class JSONFormatter(logging.Formatter):
+            def format(self, record):
+                return json.dumps(
+                    {"level": record.levelname, "message": record.getMessage()}
+                )
+
         json_handler = logging.StreamHandler(sys.stdout)
-        json_handler.setFormatter(
-            logging.Formatter('{"level": "%(levelname)s", "message": "%(message)s"}')
-        )
+        json_handler.setFormatter(JSONFormatter())
         logger.addHandler(json_handler)
 
     if log_file:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,4 +1,6 @@
 import importlib.util
+import io
+import json
 import logging
 import sys
 from pathlib import Path
@@ -64,3 +66,15 @@ def test_log_remote_handler(monkeypatch):
         "url": "/log",
         "msg": "remote-log",
     }
+
+
+def test_log_json_handler(monkeypatch):
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", buf)
+    monkeypatch.setattr(sys, "argv", ["codex-cli-linker.py", "--log-json"])
+    args = cli.parse_args()
+    cli.configure_logging(args.verbose, args.log_file, args.log_json, args.log_remote)
+    msg = 'bad "quote" \\ newline\nhere'
+    logging.warning(msg)
+    json_output = buf.getvalue().strip().splitlines()[-1]
+    assert json.loads(json_output) == {"level": "WARNING", "message": msg}


### PR DESCRIPTION
## Summary
- escape messages in JSON logging handler using a dedicated formatter
- test JSON logging handler to ensure messages are properly escaped

## Testing
- `black codex-cli-linker.py tests/test_logging.py`
- `ruff check codex-cli-linker.py tests/test_logging.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8897e670883259c6a6452b243bed7