### PR TITLE
docs: document dry-run and logging options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,11 @@ python3 codex-cli-linker.py \
 python3 codex-cli-linker.py --json --yaml
 ```
 
+**Preview config without writing files:**
+```bash
+python3 codex-cli-linker.py --dry-run --auto
+```
+
 **Show verbose logging for troubleshooting:**
 ```bash
 python3 codex-cli-linker.py --verbose --auto
@@ -148,6 +153,7 @@ python3 codex-cli-linker.py [options]
 - `--profile <NAME>` — profile name for `[profiles.<name>]` (default deduced from provider)
 - `--api-key <VAL>` — dummy key to place in an env var
 - `--env-key-name <NAME>` — env var name that holds the API key (default `NULLKEY`)
+- `--config-url <URL>` — preload flag defaults from a remote JSON before prompting
 
 **Behavior & UX**
 - `--approval-policy {untrusted,on-failure}` (default: `on-failure`)

--- a/spec.md
+++ b/spec.md
@@ -21,8 +21,10 @@
   - A profile under `[profiles.<name>]` pinning provider + model
 - Optionally emit `config.json` and `config.yaml` siblings
 - Back up existing config files before writing
+- Preview configs without writing files via `--dry-run`
 - Persist lightweight linker state (no secrets) to `~/.codex/linker_config.json`
 - Merge remote default values via `--config-url` before prompting
+- Expose verbose and remote logging controls (`--verbose`, `--log-file`, `--log-json`, `--log-remote`)
 - Offer helpful, colorized, cross‑platform UX
 
 ### Non‑Goals
@@ -73,10 +75,10 @@ save linker state → show next‑step hints
 > All flags are provided by `argparse` in `codex-cli-linker.py`.
 
 ### General
-- `--verbose` — enable INFO/DEBUG logging output
 - `--config-url <URL>` — preload defaults from a JSON config before prompts
 
 ### Logging
+- `--verbose` — enable INFO/DEBUG logging output
 - `--log-file <PATH>` — append logs to a file
 - `--log-json` — also emit logs as JSON to stdout
 - `--log-remote <URL>` — POST log records to an HTTP endpoint
@@ -140,6 +142,8 @@ save linker state → show next‑step hints
   - `~/.codex/config.toml` (always written unless `--dry-run`)
   - `~/.codex/config.json` (optional)
   - `~/.codex/config.yaml` (optional)
+- **Log file**: when `--log-file` is supplied, logs append to the given path.
+- **Remote defaults**: `--config-url` fetches a JSON file whose values are merged in-memory and not persisted.
 - **Backups**: When rewriting, existing files are moved to `<name>.<ext>.<YYYYMMDD-HHMM>.bak` allowing multiple versions to accumulate.
 - **Linker state**: `~/.codex/linker_config.json` (stores base URL, provider id, profile name, model id, approval policy, sandbox mode, reasoning defaults, verbosity, and history toggles; **no secrets**).
 - **Helper scripts**: `scripts/set_env.sh` and `scripts/set_env.bat` — set `NULLKEY` env var (customizable via `--env-key-name`).


### PR DESCRIPTION
## Summary
- detail dry-run preview and logging controls in spec
- note optional log file and remote defaults in persistence section
- expand README usage and examples for config-url, dry-run, verbose, and logging modes

## Testing
- `black .`
- `ruff check .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb3255540c8325961cea24515dfb00