### PR TITLE
Add release workflow for PyPI publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip build ruff black pytest
+          python -m pip install --upgrade pip build ruff black pytest pytest-cov
 
       - name: Lint
         run: ruff check .


### PR DESCRIPTION
## Summary
- add a release workflow triggered on pushes to main
- run linting, formatting, tests, build and publish steps with Trusted Publishing
- install pytest-cov so tests run with configured coverage options

## Testing
- `black .`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc3fe7cb888325842b81764f4d8ab5