### PR TITLE
Fix PyPI publish input names in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,5 +49,5 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages-dir: dist
-          skip-existing: true
+          packages_dir: dist
+          skip_existing: true


### PR DESCRIPTION
## Summary
- fix misnamed inputs for `gh-action-pypi-publish` to allow skipping existing files on repeated releases

## Testing
- `black .`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc4347d6f08325af266ecd8e68c51e