### PR TITLE
build: add binary release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,10 +71,10 @@ jobs:
         run: python -m pip install --upgrade pip pyinstaller
 
       - name: Build binary
-        run: pyinstaller codex-cli-linker.py --onefile
+        run: pyinstaller codex-cli-linker.py --onefile --name codex-cli-linker-${{ matrix.os }}
 
       - name: Upload binary release asset
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ github.sha }}
-          files: dist/codex-cli-linker*
+          files: dist/codex-cli-linker-${{ matrix.os }}*


### PR DESCRIPTION
## Summary
- build standalone executables for Linux, macOS, and Windows

## Testing
- `black .`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc9984f1fc8325b09ed7732a961b5f