### PR TITLE
docs: add ARM download buttons

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,15 +84,19 @@ python3 codex-cli-linker.py --full-auto   # detect server and first model (no pr
 
 ### B) Standalone executable
 Download from Releases:
-- Windows: codex-cli-linker-windows-x64.exe
-- macOS:   codex-cli-linker-macos-x64
-- Linux:   codex-cli-linker-linux-x64
+- Windows x64: codex-cli-linker-windows-x64.exe
+- macOS x64:   codex-cli-linker-macos-x64
+- macOS arm64: codex-cli-linker-macos-arm64
+- Linux x64:   codex-cli-linker-linux-x64
+- Linux arm64: codex-cli-linker-linux-arm64
 
 Direct download buttons (latest assets):
 
 <a href="https://github.com/supermarsx/codex-cli-linker/releases/latest/download/codex-cli-linker-windows-x64.exe"><img alt="Download Windows x64" src="https://img.shields.io/badge/⬇%20Windows-x64-0b5fff?logo=windows&logoColor=white" /></a>
 <a href="https://github.com/supermarsx/codex-cli-linker/releases/latest/download/codex-cli-linker-macos-x64"><img alt="Download macOS x64" src="https://img.shields.io/badge/⬇%20macOS-x64-0b5fff?logo=apple&logoColor=white" /></a>
 <a href="https://github.com/supermarsx/codex-cli-linker/releases/latest/download/codex-cli-linker-linux-x64"><img alt="Download Linux x64" src="https://img.shields.io/badge/⬇%20Linux-x64-0b5fff?logo=linux&logoColor=white" /></a>
+<a href="https://github.com/supermarsx/codex-cli-linker/releases/latest/download/codex-cli-linker-macos-arm64"><img alt="Download macOS arm64" src="https://img.shields.io/badge/⬇%20macOS-arm64-0b5fff?logo=apple&logoColor=white" /></a>
+<a href="https://github.com/supermarsx/codex-cli-linker/releases/latest/download/codex-cli-linker-linux-arm64"><img alt="Download Linux arm64" src="https://img.shields.io/badge/⬇%20Linux-arm64-0b5fff?logo=linux&logoColor=white" /></a>
 
 Or fetch via curl (latest):
 


### PR DESCRIPTION
## Summary
- add ARM binaries for macOS and Linux to README release list
- document direct download buttons for macOS ARM64 and Linux ARM64

## Testing
- `python3 -m py_compile codex-cli-linker.py`
- `python3 -m unittest -v`


------
https://chatgpt.com/codex/tasks/task_e_68c2fc972bf88325b27a9518ccf7cf92