### PR TITLE
Fix lint errors

### DIFF
--- a/codex-cli-linker.py
+++ b/codex-cli-linker.py
@@ -9,8 +9,8 @@ _src = _here / "src"
 if str(_src) not in sys.path and _src.exists():  # pragma: no cover
     sys.path.insert(0, str(_src))
 
-from codex_linker.impl import *  # type: ignore  # noqa: F401,F403
-from codex_linker.impl import main as _entry_main, warn as _warn  # type: ignore
+from codex_linker.impl import *  # type: ignore  # noqa: F401,F403,E402
+from codex_linker.impl import main as _entry_main, warn as _warn  # type: ignore  # noqa: E402
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/codex_linker/logging_utils.py
+++ b/src/codex_linker/logging_utils.py
@@ -5,6 +5,8 @@ import logging.handlers
 import os
 import sys
 import urllib.parse
+from typing import Optional
+
 
 def configure_logging(
     verbose: bool,

--- a/src/codex_linker/main_flow.py
+++ b/src/codex_linker/main_flow.py
@@ -12,11 +12,20 @@ from .logging_utils import configure_logging, log_event
 from .render import build_config_dict
 from .emit import to_toml, to_json, to_yaml
 from .detect import list_models, try_auto_context_window
-from .io_safe import (CODEX_HOME, CONFIG_TOML, CONFIG_JSON, CONFIG_YAML, LINKER_JSON, atomic_write_with_backup, delete_all_backups)
+from .io_safe import (
+    CODEX_HOME,
+    CONFIG_TOML,
+    CONFIG_JSON,
+    CONFIG_YAML,
+    LINKER_JSON,
+    atomic_write_with_backup,
+    delete_all_backups,
+)
 from .keychain import store_api_key_in_keychain
 from .state import LinkerState
-from .ui import banner, clear_screen, c, info, ok, warn, err, BOLD, CYAN
+from .ui import banner, clear_screen, c, info, ok, warn, err, CYAN
 from .utils import get_version
+
 
 def main():
     """Entry point for the CLI tool."""
@@ -169,7 +178,6 @@ def main():
             err(str(e))
             sys.exit(2)
 
-
     if not args.auto:
         interactive_prompts(args)
 
@@ -294,7 +302,6 @@ def main():
     info("Run Codex manually with:")
     print(c(f"  npx codex --profile {state.profile}", CYAN))
     print(c(f"  codex --profile {state.profile}", CYAN))
-
 
 
 __all__ = ["main"]

--- a/src/codex_linker/prompts.py
+++ b/src/codex_linker/prompts.py
@@ -4,14 +4,14 @@ from typing import List, Optional
 from .spec import DEFAULT_LMSTUDIO, DEFAULT_OLLAMA
 from .detect import detect_base_url, list_models
 from .state import LinkerState
-from .ui import err, c, BOLD, CYAN, info, ok, warn
+from .ui import err, c, BOLD, CYAN, info, warn
 
 
 def prompt_choice(prompt: str, options: List[str]) -> int:
     """Display a numbered list and return the selected zero-based index."""
     for i, opt in enumerate(options, 1):
         print(f"  {i}. {opt}")
-        
+
     while True:
         s = input(f"{prompt} [1-{len(options)}]: ").strip()
         if s.isdigit() and 1 <= int(s) <= len(options):
@@ -123,4 +123,10 @@ def interactive_prompts(args) -> None:
     args.hide_agent_reasoning = not show
 
 
-__all__ = ["prompt_choice", "prompt_yes_no", "pick_base_url", "pick_model_interactive", "interactive_prompts"]
+__all__ = [
+    "prompt_choice",
+    "prompt_yes_no",
+    "pick_base_url",
+    "pick_model_interactive",
+    "interactive_prompts",
+]


### PR DESCRIPTION
## Summary
- silence E402 import position warnings in compatibility shim
- add missing Optional import for logging utils and drop unused imports

## Testing
- `ruff check .`
- `python3 -m py_compile codex-cli-linker.py`
- `python3 -m unittest -v`


------
https://chatgpt.com/codex/tasks/task_e_68c43553b31883259de4facfb9576fed