### PR TITLE
Improve CLI detection and config path handling

### DIFF
--- a/codex-cli-linker.py
+++ b/codex-cli-linker.py
@@ -11,6 +11,12 @@ if str(_src) not in sys.path and _src.exists():  # pragma: no cover
 
 from codex_linker.impl import *  # type: ignore  # noqa: F401,F403,E402
 from codex_linker.impl import main as _entry_main, warn as _warn  # type: ignore  # noqa: E402
+from codex_linker import utils as _utils  # noqa: E402
+
+
+def launch_codex(profile: str) -> int:  # noqa: D401
+    """Wrapper that forwards to utils.launch_codex using this module's ensure."""
+    return _utils.launch_codex(profile, ensure_codex_cli)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/codex_linker/config_utils.py
+++ b/src/codex_linker/config_utils.py
@@ -39,7 +39,9 @@ def apply_saved_state(
         "history_max_bytes",
     ):
         if fld not in specified and getattr(args, fld) == getattr(defaults, fld):
-            setattr(args, fld, getattr(state, fld))
+            val = getattr(state, fld)
+            if val:
+                setattr(args, fld, val)
 
 
 # =============== Main flow ===============

--- a/src/codex_linker/render.py
+++ b/src/codex_linker/render.py
@@ -22,7 +22,7 @@ def build_config_dict(state: LinkerState, args: argparse.Namespace) -> Dict:
     # within the configuration structure.
     cfg: Dict[str, Any] = {
         "model": args.model or state.model or "gpt-5",
-        "model_provider": state.provider,
+        "model_provider": args.provider or state.provider,
         "approval_policy": args.approval_policy,
         "sandbox_mode": args.sandbox_mode,
         "file_opener": args.file_opener,
@@ -35,7 +35,7 @@ def build_config_dict(state: LinkerState, args: argparse.Namespace) -> Dict:
         "model_reasoning_effort": args.reasoning_effort,
         "model_reasoning_summary": args.reasoning_summary,
         "model_verbosity": args.verbosity,
-        "profile": state.profile,
+        "profile": args.profile or state.profile,
         "model_context_window": args.model_context_window or 0,
         "model_max_output_tokens": args.model_max_output_tokens or 0,
         "project_doc_max_bytes": args.project_doc_max_bytes,
@@ -56,7 +56,7 @@ def build_config_dict(state: LinkerState, args: argparse.Namespace) -> Dict:
             "max_bytes": args.history_max_bytes,
         },
         "model_providers": {
-            state.provider: {
+            (args.provider or state.provider): {
                 "name": (
                     "LM Studio"
                     if state.base_url.startswith("http://localhost:1234")
@@ -95,16 +95,16 @@ def build_config_dict(state: LinkerState, args: argparse.Namespace) -> Dict:
                 ),
                 "base_url": state.base_url.rstrip("/"),
                 "wire_api": "chat",
-                "api_key_env_var": state.env_key,
+                "api_key_env_var": state.env_key or "NULLKEY",
                 "request_max_retries": args.request_max_retries,
                 "stream_max_retries": args.stream_max_retries,
                 "stream_idle_timeout_ms": args.stream_idle_timeout_ms,
             }
         },
         "profiles": {
-            state.profile: {
+            (args.profile or state.profile): {
                 "model": args.model or state.model or "gpt-5",
-                "model_provider": state.provider,
+                "model_provider": args.provider or state.provider,
                 "model_context_window": args.model_context_window or 0,
                 "model_max_output_tokens": args.model_max_output_tokens or 0,
                 "approval_policy": args.approval_policy,
@@ -112,7 +112,7 @@ def build_config_dict(state: LinkerState, args: argparse.Namespace) -> Dict:
         },
     }
     if args.azure_api_version:
-        cfg["model_providers"][state.provider]["query_params"] = {
+        cfg["model_providers"][args.provider or state.provider]["query_params"] = {
             "api-version": args.azure_api_version
         }
     extra = getattr(args, "providers_list", []) or []


### PR DESCRIPTION
## Summary
- Normalize Codex CLI lookup and allow injection for testing
- Detect version from package or pyproject and handle unknown cases
- Respect environment overrides for backups and config paths

## Testing
- `python3 -m py_compile codex-cli-linker.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c498e775748325b92ceb316193d678