### PR TITLE
Fix YAML dump newline handling

### DIFF
--- a/src/codex_linker/emit.py
+++ b/src/codex_linker/emit.py
@@ -192,7 +192,7 @@ def to_yaml(cfg: Dict) -> str:
                     out.append(dump(v, indent + 1))
                 else:
                     out.append(f"{sp}{k}: {json.dumps(v)}")
-            return "".join(out)
+            return "\n".join(out)
         elif isinstance(obj, list):
             out: List[str] = []
             for v in obj:
@@ -201,11 +201,11 @@ def to_yaml(cfg: Dict) -> str:
                     out.append(dump(v, indent + 1))
                 else:
                     out.append(f"{sp}- {json.dumps(v)}")
-            return "".join(out)
+            return "\n".join(out)
         else:
             return f"{sp}{json.dumps(obj)}"
 
-    return dump(cfg) + ""
+    return dump(cfg) + "\n"
 
 
 __all__ = ["to_toml", "to_json", "to_yaml"]


### PR DESCRIPTION
## Summary
- ensure YAML dump helper joins lines with newlines so nested structures keep indentation
- return YAML strings with a trailing newline

## Testing
- `ruff check --fix src/codex_linker/emit.py`
- `black src/codex_linker/emit.py`
- `PYTHONPATH=src python3 -m unittest -v`


------
https://chatgpt.com/codex/tasks/task_e_68c6adebc8dc8325927fd08d951ae1ce