### PR TITLE
Refactor provider detection into shared helper

### DIFF
--- a/codex-cli-linker.py
+++ b/codex-cli-linker.py
@@ -82,6 +82,7 @@ urllib = _impl.urllib
 logging = _impl.logging
 datetime = _impl.datetime
 main = _impl.main
+resolve_provider = _impl.resolve_provider
 
 __all__ = [
     "parse_args",
@@ -150,6 +151,7 @@ __all__ = [
     "logging",
     "datetime",
     "main",
+    "resolve_provider",
 ]
 
 

--- a/src/codex_linker/impl.py
+++ b/src/codex_linker/impl.py
@@ -68,6 +68,7 @@ from .utils import (
     find_codex_cmd,
     ensure_codex_cli,
     launch_codex,
+    resolve_provider,
 )
 from .main_flow import main
 
@@ -121,6 +122,7 @@ __all__ = [
     "find_codex_cmd",
     "ensure_codex_cli",
     "launch_codex",
+    "resolve_provider",
     "CODEX_HOME",
     "CONFIG_TOML",
     "CONFIG_JSON",

--- a/tests/test_interactive_and_utils.py
+++ b/tests/test_interactive_and_utils.py
@@ -174,3 +174,10 @@ def test_ui_helpers_no_crash(monkeypatch, capsys):
     # clear_screen and banner shouldn't raise
     cli.clear_screen()
     cli.banner()
+
+
+def test_resolve_provider_mapping():
+    cli = load_cli()
+    assert cli.resolve_provider(cli.DEFAULT_LMSTUDIO) == "lmstudio"
+    assert cli.resolve_provider(cli.DEFAULT_OLLAMA) == "ollama"
+    assert cli.resolve_provider("http://example.com/v1") == "custom"


### PR DESCRIPTION
## Summary
- add `resolve_provider` helper to map base URLs to provider IDs
- use helper in CLI flow and config rendering
- test provider resolution behavior

## Testing
- `ruff check src/codex_linker/utils.py src/codex_linker/main_flow.py src/codex_linker/render.py src/codex_linker/impl.py codex-cli-linker.py tests/test_interactive_and_utils.py`
- `black src/codex_linker/utils.py src/codex_linker/main_flow.py src/codex_linker/render.py src/codex_linker/impl.py codex-cli-linker.py tests/test_interactive_and_utils.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6b1d778108325905c9b1e8839cb1b